### PR TITLE
v3a - internal test framework files for standardization of is_not/not_in;

### DIFF
--- a/lib/sqlalchemy/testing/__init__.py
+++ b/lib/sqlalchemy/testing/__init__.py
@@ -29,11 +29,13 @@ from .assertions import in_  # noqa
 from .assertions import is_  # noqa
 from .assertions import is_false  # noqa
 from .assertions import is_instance_of  # noqa
-from .assertions import is_not_  # noqa
+from .assertions import is_not  # noqa
+from .assertions import is_not_  # noqa Issue#5429 Legacy Support
 from .assertions import is_true  # noqa
 from .assertions import le_  # noqa
 from .assertions import ne_  # noqa
-from .assertions import not_in_  # noqa
+from .assertions import not_in  # noqa
+from .assertions import not_in_  # noqa Issue#5429 Legacy Support
 from .assertions import startswith_  # noqa
 from .assertions import uses_deprecated  # noqa
 from .config import async_test  # noqa

--- a/lib/sqlalchemy/testing/assertions.py
+++ b/lib/sqlalchemy/testing/assertions.py
@@ -234,9 +234,13 @@ def is_(a, b, msg=None):
     assert a is b, msg or "%r is not %r" % (a, b)
 
 
-def is_not_(a, b, msg=None):
+def is_not(a, b, msg=None):
     """Assert a is not b, with repr messaging on failure."""
     assert a is not b, msg or "%r is %r" % (a, b)
+
+
+# SqlAlchemy 1.4 deprecates legacy terms for standardizations (see Issue#5429)
+is_not_ = is_not
 
 
 def in_(a, b, msg=None):
@@ -244,9 +248,13 @@ def in_(a, b, msg=None):
     assert a in b, msg or "%r not in %r" % (a, b)
 
 
-def not_in_(a, b, msg=None):
+def not_in(a, b, msg=None):
     """Assert a in not b, with repr messaging on failure."""
     assert a not in b, msg or "%r is in %r" % (a, b)
+
+
+# SqlAlchemy 1.4 deprecates legacy terms for standardizations (see Issue#5429)
+not_in_ = not_in
 
 
 def startswith_(a, fragment, msg=None):

--- a/test/base/test_events.py
+++ b/test/base/test_events.py
@@ -9,7 +9,8 @@ from sqlalchemy.testing import eq_
 from sqlalchemy.testing import expect_deprecated
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing.mock import call
 from sqlalchemy.testing.mock import Mock
 from sqlalchemy.testing.util import gc_collect
@@ -163,7 +164,7 @@ class EventsTest(fixtures.TestBase):
         def listen_two(x, y):
             pass
 
-        is_not_(
+        is_not(
             self.Target.dispatch._empty_listener_reg[self.Target]["event_one"],
             t1.dispatch.event_one,
         )

--- a/test/dialect/mssql/test_types.py
+++ b/test/dialect/mssql/test_types.py
@@ -51,7 +51,8 @@ from sqlalchemy.testing import engines
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import pickleable
 from sqlalchemy.util import b
 
@@ -1057,7 +1058,7 @@ class TypeRoundTripTest(
                     is_(tbl._autoincrement_column, col)
                 else:
                     eq_(col.autoincrement, "auto")
-                    is_not_(tbl._autoincrement_column, col)
+                    is_not(tbl._autoincrement_column, col)
 
             # mxodbc can't handle scope_identity() with DEFAULT VALUES
 

--- a/test/dialect/test_all.py
+++ b/test/dialect/test_all.py
@@ -1,6 +1,7 @@
 from sqlalchemy import dialects
 from sqlalchemy.testing import fixtures
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 
 
 class ImportStarTest(fixtures.TestBase):
@@ -14,4 +15,4 @@ class ImportStarTest(fixtures.TestBase):
     def test_all_import(self):
         for package in self._all_dialect_packages():
             for item_name in package.__all__:
-                is_not_(None, getattr(package, item_name))
+                is_not(None, getattr(package, item_name))

--- a/test/engine/test_execute.py
+++ b/test/engine/test_execute.py
@@ -39,7 +39,8 @@ from sqlalchemy.testing import expect_warnings
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
 from sqlalchemy.testing import is_false
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import is_true
 from sqlalchemy.testing import mock
 from sqlalchemy.testing.assertsql import CompiledSQL
@@ -2510,7 +2511,7 @@ class HandleErrorTest(fixtures.TestBase):
 
         for crec in crecs:
             if crec is target_crec or not set_to_false:
-                is_not_(crec.connection, crec.get_connection())
+                is_not(crec.connection, crec.get_connection())
             else:
                 is_(crec.connection, crec.get_connection())
 
@@ -2875,7 +2876,7 @@ class HandleInvalidatedOnConnectTest(fixtures.TestBase):
         c2 = eng.connect()
         dbapi_conn_two = c2.connection.connection
 
-        is_not_(dbapi_conn_one, dbapi_conn_two)
+        is_not(dbapi_conn_one, dbapi_conn_two)
 
         eq_(
             m1.mock_calls,

--- a/test/engine/test_pool.py
+++ b/test/engine/test_pool.py
@@ -15,7 +15,8 @@ from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import is_true
 from sqlalchemy.testing.engines import testing_engine
 from sqlalchemy.testing.mock import ANY
@@ -151,7 +152,7 @@ class PoolTest(PoolTestBase):
         self.assert_("foo2" in c.info)
 
         c2 = p.connect()
-        is_not_(c.connection, c2.connection)
+        is_not(c.connection, c2.connection)
         assert not c2.info
         assert "foo2" in c.info
 
@@ -215,7 +216,7 @@ class PoolTest(PoolTestBase):
 
         c2 = r1.get_connection()
 
-        is_not_(c1, c2)
+        is_not(c1, c2)
         is_(c2, r1.connection)
 
         eq_(c2.mock_calls, [])
@@ -1203,7 +1204,7 @@ class QueuePoolTest(PoolTestBase):
 
             mock.return_value = 10035
             c3 = p.connect()
-            is_not_(c3.connection, c_ref())
+            is_not(c3.connection, c_ref())
 
     @testing.requires.timing_intensive
     def test_recycle_on_invalidate(self):
@@ -1221,7 +1222,7 @@ class QueuePoolTest(PoolTestBase):
         time.sleep(0.5)
         c3 = p.connect()
 
-        is_not_(c3.connection, c_ref())
+        is_not(c3.connection, c_ref())
 
     @testing.requires.timing_intensive
     def test_recycle_on_soft_invalidate(self):
@@ -1244,7 +1245,7 @@ class QueuePoolTest(PoolTestBase):
         c2.close()
 
         c3 = p.connect()
-        is_not_(c3.connection, c_ref())
+        is_not(c3.connection, c_ref())
         is_(c3._connection_record, c2_rec)
         is_(c2_rec.connection, c3.connection)
 

--- a/test/engine/test_reflection.py
+++ b/test/engine/test_reflection.py
@@ -28,10 +28,12 @@ from sqlalchemy.testing import in_
 from sqlalchemy.testing import is_
 from sqlalchemy.testing import is_false
 from sqlalchemy.testing import is_instance_of
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import is_true
 from sqlalchemy.testing import mock
-from sqlalchemy.testing import not_in_
+from sqlalchemy.testing import not_in
+from sqlalchemy.testing import not_in_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import skip
 from sqlalchemy.testing.schema import Column
 from sqlalchemy.testing.schema import Table
@@ -166,7 +168,7 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
         meta2 = MetaData()
         t1 = Table("t1", meta2, resolve_fks=False, autoload_with=testing.db)
         in_("t1", meta2.tables)
-        not_in_("t2", meta2.tables)
+        not_in("t2", meta2.tables)
 
         assert_raises(
             sa.exc.NoReferencedTableError,
@@ -206,7 +208,7 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
             autoload_with=testing.db,
             extend_existing=True,
         )
-        not_in_("t2", meta2.tables)
+        not_in("t2", meta2.tables)
 
         assert_raises(
             sa.exc.NoReferencedTableError,
@@ -238,7 +240,7 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
         meta2 = MetaData()
         meta2.reflect(testing.db, resolve_fks=False, only=["t1"])
         in_("t1", meta2.tables)
-        not_in_("t2", meta2.tables)
+        not_in("t2", meta2.tables)
 
         t1 = meta2.tables["t1"]
 
@@ -2273,7 +2275,7 @@ class ComputedColumnTest(fixtures.ComputedReflectionFixtureTest):
     def check_table_column(self, table, name, text, persisted):
         is_true(name in table.columns)
         col = table.columns[name]
-        is_not_(col.computed, None)
+        is_not(col.computed, None)
         is_instance_of(col.computed, Computed)
 
         eq_(self.normalize(str(col.computed.sqltext)), text)

--- a/test/ext/test_baked.py
+++ b/test/ext/test_baked.py
@@ -16,7 +16,8 @@ from sqlalchemy.orm.query import Query
 from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import mock
 from test.orm import _fixtures
 
@@ -101,7 +102,7 @@ class StateChangeTest(BakedTest):
         q1 = self.bakery(l1)
 
         q2 = q1.with_criteria(l2)
-        is_not_(q2, q1)
+        is_not(q2, q1)
 
         self._assert_cache_key(q1._cache_key, [l1])
         self._assert_cache_key(q2._cache_key, [l1, l2])
@@ -119,7 +120,7 @@ class StateChangeTest(BakedTest):
         q1 = self.bakery(l1)
 
         q2 = q1 + l2
-        is_not_(q2, q1)
+        is_not(q2, q1)
 
         self._assert_cache_key(q1._cache_key, [l1])
         self._assert_cache_key(q2._cache_key, [l1, l2])

--- a/test/ext/test_indexable.py
+++ b/test/ext/test_indexable.py
@@ -14,7 +14,8 @@ from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import in_
 from sqlalchemy.testing import is_
 from sqlalchemy.testing import ne_
-from sqlalchemy.testing import not_in_
+from sqlalchemy.testing import not_in
+from sqlalchemy.testing import not_in_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing.schema import Column
 
 
@@ -246,7 +247,7 @@ class IndexPropertyArrayTest(fixtures.DeclarativeMappedTest):
         a.first = 10
 
         is_(i.modified, True)
-        not_in_("array", i.unmodified)
+        not_in("array", i.unmodified)
 
 
 class IndexPropertyJsonTest(fixtures.DeclarativeMappedTest):
@@ -339,7 +340,7 @@ class IndexPropertyJsonTest(fixtures.DeclarativeMappedTest):
         j.other = 42
 
         is_(i.modified, True)
-        not_in_("json", i.unmodified)
+        not_in("json", i.unmodified)
 
     def test_cast_type(self):
         Json = self.classes.Json

--- a/test/orm/test_attributes.py
+++ b/test/orm/test_attributes.py
@@ -14,9 +14,11 @@ from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
 from sqlalchemy.testing import is_false
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import is_true
-from sqlalchemy.testing import not_in_
+from sqlalchemy.testing import not_in
+from sqlalchemy.testing import not_in_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing.mock import call
 from sqlalchemy.testing.mock import Mock
 from sqlalchemy.testing.util import all_partial_orderings
@@ -3710,10 +3712,10 @@ class CollectionInitTest(fixtures.TestBase):
         existing = a1.bs
 
         is_(state._empty_collections["bs"], existing)
-        is_not_(existing._sa_adapter, None)
+        is_not(existing._sa_adapter, None)
 
         a1.bs = []  # replaces previous "empty" collection
-        not_in_("bs", state._empty_collections)  # empty is replaced
+        not_in("bs", state._empty_collections)  # empty is replaced
         is_(existing._sa_adapter, None)
 
     def test_assert_false_on_default_value(self):
@@ -3735,7 +3737,7 @@ class CollectionInitTest(fixtures.TestBase):
         eq_(a1.__dict__["bs"], [b1, b2])
 
         old = a1.__dict__["bs"]
-        is_not_(old._sa_adapter, None)
+        is_not(old._sa_adapter, None)
         state = attributes.instance_state(a1)
 
         # this occurs during a load with populate_existing

--- a/test/orm/test_cascade.py
+++ b/test/orm/test_cascade.py
@@ -26,7 +26,8 @@ from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import in_
-from sqlalchemy.testing import not_in_
+from sqlalchemy.testing import not_in
+from sqlalchemy.testing import not_in_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing.schema import Column
 from sqlalchemy.testing.schema import Table
 from test.orm import _fixtures
@@ -4206,8 +4207,8 @@ class ViewonlyFlagWarningTest(fixtures.MappedTest):
 
         sess.expunge(u1)
 
-        not_in_(orders[0], sess)
-        not_in_(orders[1], sess)
+        not_in(orders[0], sess)
+        not_in(orders[1], sess)
 
     def test_default_none_cascade(self):
         User, Order, orders, users = (
@@ -4245,8 +4246,8 @@ class ViewonlyFlagWarningTest(fixtures.MappedTest):
         u1.orders.append(o1)
         u1.orders.append(o2)
 
-        not_in_(o1, sess)
-        not_in_(o2, sess)
+        not_in(o1, sess)
+        not_in(o2, sess)
 
     def test_default_merge_cascade(self):
         User, Order, orders, users = (

--- a/test/orm/test_eager_relations.py
+++ b/test/orm/test_eager_relations.py
@@ -35,7 +35,8 @@ from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import in_
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing.assertsql import CompiledSQL
 from sqlalchemy.testing.schema import Column
 from sqlalchemy.testing.schema import Table
@@ -1698,7 +1699,7 @@ class EagerTest(_fixtures.FixtureTest, testing.AssertsCompiledSQL):
 
         def go():
             a = q.filter(addresses.c.id == 1).one()
-            is_not_(a.user, None)
+            is_not(a.user, None)
             u1 = sess.query(User).get(7)
             is_(a.user, u1)
 

--- a/test/orm/test_events.py
+++ b/test/orm/test_events.py
@@ -28,7 +28,8 @@ from sqlalchemy.testing import AssertsCompiledSQL
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import expect_warnings
 from sqlalchemy.testing import fixtures
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing.assertsql import CompiledSQL
 from sqlalchemy.testing.mock import ANY
 from sqlalchemy.testing.mock import call
@@ -2270,7 +2271,7 @@ class SessionLifecycleEventsTest(_RemoveListeners, _fixtures.FixtureTest):
             listener.flag_checked(instance)
             # this is actually u1, because
             # we have a strong ref internally
-            is_not_(None, instance)
+            is_not(None, instance)
 
         u1 = User(name="u1")
         sess.add(u1)
@@ -2303,7 +2304,7 @@ class SessionLifecycleEventsTest(_RemoveListeners, _fixtures.FixtureTest):
 
         @event.listens_for(sess, "persistent_to_deleted")
         def persistent_to_deleted(session, instance):
-            is_not_(None, instance)
+            is_not(None, instance)
             listener.flag_checked(instance)
 
         sess.delete(u1)

--- a/test/orm/test_merge.py
+++ b/test/orm/test_merge.py
@@ -29,7 +29,8 @@ from sqlalchemy.testing import eq_
 from sqlalchemy.testing import expect_warnings
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import in_
-from sqlalchemy.testing import not_in_
+from sqlalchemy.testing import not_in
+from sqlalchemy.testing import not_in_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing.schema import Column
 from sqlalchemy.testing.schema import Table
 from sqlalchemy.util import OrderedSet
@@ -1839,7 +1840,7 @@ class DeferredMergeTest(fixtures.MappedTest):
 
             # should not emit load for deferred 'excerpt'
             eq_(b2.summary, "some summary")
-            not_in_("excerpt", b2.__dict__)
+            not_in("excerpt", b2.__dict__)
 
             # now it should emit load for deferred 'excerpt'
             eq_(b2.excerpt, "some excerpt")
@@ -1885,7 +1886,7 @@ class DeferredMergeTest(fixtures.MappedTest):
 
             # should not emit load for deferred 'excerpt'
             eq_(b2.summary, "some summary")
-            not_in_("excerpt", b2.__dict__)
+            not_in("excerpt", b2.__dict__)
 
             # now it should emit load for deferred 'excerpt'
             eq_(b2.excerpt, "some excerpt")

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -25,7 +25,8 @@ from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import is_true
 from sqlalchemy.testing import mock
 from sqlalchemy.testing.assertsql import AllOf
@@ -1174,7 +1175,7 @@ class EagerTest(_fixtures.FixtureTest, testing.AssertsCompiledSQL):
 
         def go():
             a = q.filter(addresses.c.id == 1).one()
-            is_not_(a.user, None)
+            is_not(a.user, None)
             u1 = sess.query(User).get(7)
             is_(a.user, u1)
 

--- a/test/orm/test_session.py
+++ b/test/orm/test_session.py
@@ -29,7 +29,8 @@ from sqlalchemy.testing import engines
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import is_true
 from sqlalchemy.testing import mock
 from sqlalchemy.testing import pickleable
@@ -130,19 +131,19 @@ class TransScopingTest(_fixtures.FixtureTest):
         is_(s._transaction, None)
 
         s.execute(select(1))
-        is_not_(s._transaction, None)
+        is_not(s._transaction, None)
 
         s.commit()
         is_(s._transaction, None)
 
         s.execute(select(1))
-        is_not_(s._transaction, None)
+        is_not(s._transaction, None)
 
         s.close()
         is_(s._transaction, None)
 
         s.execute(select(1))
-        is_not_(s._transaction, None)
+        is_not(s._transaction, None)
 
         s.close()
         is_(s._transaction, None)
@@ -163,7 +164,7 @@ class TransScopingTest(_fixtures.FixtureTest):
 
         s.add(User(id=1, name="name"))
         s.flush()
-        is_not_(s._transaction, None)
+        is_not(s._transaction, None)
         s.commit()
         is_(s._transaction, None)
 

--- a/test/orm/test_subquery_relations.py
+++ b/test/orm/test_subquery_relations.py
@@ -24,7 +24,8 @@ from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import is_true
 from sqlalchemy.testing.assertsql import CompiledSQL
 from sqlalchemy.testing.entities import ComparableEntity
@@ -1236,7 +1237,7 @@ class EagerTest(_fixtures.FixtureTest, testing.AssertsCompiledSQL):
 
         def go():
             a = q.filter(addresses.c.id == 1).one()
-            is_not_(a.user, None)
+            is_not(a.user, None)
             u1 = sess.query(User).get(7)
             is_(a.user, u1)
 

--- a/test/orm/test_transaction.py
+++ b/test/orm/test_transaction.py
@@ -30,7 +30,8 @@ from sqlalchemy.testing import eq_
 from sqlalchemy.testing import expect_warnings
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import mock
 from sqlalchemy.testing.util import gc_collect
 from test.orm._fixtures import FixtureTest
@@ -809,7 +810,7 @@ class SessionTransactionTest(fixtures.RemovesEvents, FixtureTest):
         eq_(trans._state, _session.CLOSED)
 
         # outermost transaction is new
-        is_not_(session._transaction, trans)
+        is_not(session._transaction, trans)
 
         is_(session._transaction, None)
         eq_(session.is_active, True)
@@ -1026,7 +1027,7 @@ class SessionTransactionTest(fixtures.RemovesEvents, FixtureTest):
         session.add(User(name="ed"))
         session.transaction.commit()
 
-        is_not_(session.transaction, None)
+        is_not(session.transaction, None)
 
     def test_no_autocommit_with_explicit_commit_future(self):
         User, users = self.classes.User, self.tables.users
@@ -1880,7 +1881,7 @@ class SavepointTest(_LocalFixture):
         assert u1 not in s.new
 
         is_(trans._state, _session.CLOSED)
-        is_not_(s.transaction, trans)
+        is_not(s.transaction, trans)
         is_(s.transaction._state, _session.ACTIVE)
 
         is_(s.transaction.nested, False)
@@ -2134,13 +2135,13 @@ class ContextManagerPlusFutureTest(FixtureTest):
 
         s1.commit()
         eq_(s1.connection().scalar(select(func.count()).select_from(users)), 1)
-        is_not_(s1.transaction, None)
+        is_not(s1.transaction, None)
 
     def test_session_as_ctx_manager_one(self):
         users = self.tables.users
 
         with Session(testing.db) as sess:
-            is_not_(sess.transaction, None)
+            is_not(sess.transaction, None)
 
             sess.connection().execute(
                 users.insert().values(id=1, name="user1")
@@ -2150,9 +2151,9 @@ class ContextManagerPlusFutureTest(FixtureTest):
                 sess.connection().execute(users.select()).all(), [(1, "user1")]
             )
 
-            is_not_(sess.transaction, None)
+            is_not(sess.transaction, None)
 
-        is_not_(sess.transaction, None)
+        is_not(sess.transaction, None)
 
         # did not commit
         eq_(sess.connection().execute(users.select()).all(), [])
@@ -2171,7 +2172,7 @@ class ContextManagerPlusFutureTest(FixtureTest):
                 sess.connection().execute(users.select()).all(), [(1, "user1")]
             )
 
-            is_not_(sess.transaction, None)
+            is_not(sess.transaction, None)
 
         is_(sess.transaction, None)
 
@@ -2183,7 +2184,7 @@ class ContextManagerPlusFutureTest(FixtureTest):
 
         try:
             with Session(testing.db) as sess:
-                is_not_(sess.transaction, None)
+                is_not(sess.transaction, None)
 
                 sess.connection().execute(
                     users.insert().values(id=1, name="user1")
@@ -2192,7 +2193,7 @@ class ContextManagerPlusFutureTest(FixtureTest):
                 raise Exception("force rollback")
         except:
             pass
-        is_not_(sess.transaction, None)
+        is_not(sess.transaction, None)
 
     def test_session_as_ctx_manager_two_future(self):
         users = self.tables.users

--- a/test/orm/test_update_delete.py
+++ b/test/orm/test_update_delete.py
@@ -25,7 +25,8 @@ from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import in_
-from sqlalchemy.testing import not_in_
+from sqlalchemy.testing import not_in
+from sqlalchemy.testing import not_in_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing.assertsql import CompiledSQL
 from sqlalchemy.testing.schema import Column
 from sqlalchemy.testing.schema import Table
@@ -704,9 +705,9 @@ class UpdateDeleteTest(fixtures.MappedTest):
             )
 
         in_(john, sess)
-        not_in_(jack, sess)
+        not_in(jack, sess)
         in_(jill, sess)
-        not_in_(jane, sess)
+        not_in(jane, sess)
 
     def test_delete_fetch_returning_lambda(self):
         User = self.classes.User
@@ -749,9 +750,9 @@ class UpdateDeleteTest(fixtures.MappedTest):
             )
 
         in_(john, sess)
-        not_in_(jack, sess)
+        not_in(jack, sess)
         in_(jill, sess)
-        not_in_(jane, sess)
+        not_in(jane, sess)
 
     def test_update_with_filter_statement(self):
         """test for [ticket:4556] """

--- a/test/sql/test_compare.py
+++ b/test/sql/test_compare.py
@@ -68,7 +68,8 @@ from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
 from sqlalchemy.testing import is_false
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import is_true
 from sqlalchemy.testing import ne_
 from sqlalchemy.testing.util import random_choices
@@ -1102,8 +1103,8 @@ class CacheKeyTest(CacheKeyFixture, CoreFixtures, fixtures.TestBase):
         ck2 = s2._generate_cache_key()
 
         ne_(ck1, ck2)
-        is_not_(ck1, None)
-        is_not_(ck2, None)
+        is_not(ck1, None)
+        is_not(ck2, None)
 
     def test_generative_cache_key_regen_w_del(self):
         t1 = table("t1", column("a"), column("b"))
@@ -1124,8 +1125,8 @@ class CacheKeyTest(CacheKeyFixture, CoreFixtures, fixtures.TestBase):
         ck3 = s3._generate_cache_key()
 
         ne_(ck1, ck3)
-        is_not_(ck1, None)
-        is_not_(ck3, None)
+        is_not(ck1, None)
+        is_not(ck3, None)
 
 
 class CompareAndCopyTest(CoreFixtures, fixtures.TestBase):

--- a/test/sql/test_computed.py
+++ b/test/sql/test_computed.py
@@ -11,7 +11,8 @@ from sqlalchemy.testing import AssertsCompiledSQL
 from sqlalchemy.testing import combinations
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 
 
 class DDLComputedTest(fixtures.TestBase, AssertsCompiledSQL):
@@ -83,7 +84,7 @@ class DDLComputedTest(fixtures.TestBase, AssertsCompiledSQL):
         t2 = t.to_metadata(m2)
         comp2 = t2.c.y.server_default
 
-        is_not_(comp1, comp2)
+        is_not(comp1, comp2)
 
         is_(comp1.column, t.c.y)
         is_(t.c.y.server_onupdate, comp1)

--- a/test/sql/test_deprecations.py
+++ b/test/sql/test_deprecations.py
@@ -41,7 +41,8 @@ from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import in_
 from sqlalchemy.testing import is_true
 from sqlalchemy.testing import mock
-from sqlalchemy.testing import not_in_
+from sqlalchemy.testing import not_in
+from sqlalchemy.testing import not_in_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing.schema import Column
 from sqlalchemy.testing.schema import Table
 
@@ -991,8 +992,8 @@ class KeyTargetingTest(fixtures.TablesTest):
             select(content.c.type.label("content_type"))
         ).first()
 
-        not_in_(content.c.type, row)
-        not_in_(bar.c.content_type, row)
+        not_in(content.c.type, row)
+        not_in(bar.c.content_type, row)
 
         with testing.expect_deprecated(
             "Retrieving row values using Column objects "
@@ -1003,8 +1004,8 @@ class KeyTargetingTest(fixtures.TablesTest):
         row = connection.execute(
             select(func.now().label("content_type"))
         ).first()
-        not_in_(content.c.type, row)
-        not_in_(bar.c.content_type, row)
+        not_in(content.c.type, row)
+        not_in(bar.c.content_type, row)
         with testing.expect_deprecated(
             "Retrieving row values using Column objects "
             "with only matching names"
@@ -1286,7 +1287,7 @@ class CursorResultTest(fixtures.TablesTest):
 
         row = connection.execute(content.select().apply_labels()).first()
         in_(content.c.type, row._mapping)
-        not_in_(bar.c.content_type, row)
+        not_in(bar.c.content_type, row)
         with testing.expect_deprecated(
             "Retrieving row values using Column objects "
             "with only matching names"
@@ -1302,7 +1303,7 @@ class CursorResultTest(fixtures.TablesTest):
         ):
             in_(content.c.type, row)
 
-        not_in_(bar.c.content_type, row)
+        not_in(bar.c.content_type, row)
 
         with testing.expect_deprecated(
             "Retrieving row values using Column objects "
@@ -1314,9 +1315,9 @@ class CursorResultTest(fixtures.TablesTest):
             select(func.now().label("content_type"))
         ).first()
 
-        not_in_(content.c.type, row)
+        not_in(content.c.type, row)
 
-        not_in_(bar.c.content_type, row)
+        not_in(bar.c.content_type, row)
 
         with testing.expect_deprecated(
             "Retrieving row values using Column objects "
@@ -1543,7 +1544,7 @@ class CursorResultTest(fixtures.TablesTest):
             in_("user_name", r)
 
         # no warning if the key is not there
-        not_in_("foobar", r)
+        not_in("foobar", r)
 
         # this seems to happen only with Python BaseRow
         # with testing.expect_deprecated(

--- a/test/sql/test_external_traversal.py
+++ b/test/sql/test_external_traversal.py
@@ -36,7 +36,8 @@ from sqlalchemy.testing import AssertsExecutionResults
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 
 A = B = t1 = t2 = t3 = table1 = table2 = table3 = table4 = None
 
@@ -447,7 +448,7 @@ class ClauseTest(fixtures.TestBase, AssertsCompiledSQL):
         adapter = sql_util.ColumnAdapter(t3_alias)
 
         lblx_adapted = adapter.traverse(lbl_x)
-        is_not_(lblx_adapted._element, lbl_x._element)
+        is_not(lblx_adapted._element, lbl_x._element)
 
         lblx_adapted = adapter.traverse(lbl_x)
         self.assert_compile(
@@ -1017,7 +1018,7 @@ class ColumnAdapterTest(fixtures.TestBase, AssertsCompiledSQL):
 
         expr = select(t1a.c.col1).label("x")
         expr_adapted = adapter.traverse(expr)
-        is_not_(expr, expr_adapted)
+        is_not(expr, expr_adapted)
         is_(adapter.columns[expr], expr_adapted)
 
     def test_traverse_memoizes_w_itself(self):
@@ -1026,7 +1027,7 @@ class ColumnAdapterTest(fixtures.TestBase, AssertsCompiledSQL):
 
         expr = select(t1a.c.col1).label("x")
         expr_adapted = adapter.traverse(expr)
-        is_not_(expr, expr_adapted)
+        is_not(expr, expr_adapted)
         is_(adapter.traverse(expr), expr_adapted)
 
     def test_columns_memoizes_w_itself(self):
@@ -1035,7 +1036,7 @@ class ColumnAdapterTest(fixtures.TestBase, AssertsCompiledSQL):
 
         expr = select(t1a.c.col1).label("x")
         expr_adapted = adapter.columns[expr]
-        is_not_(expr, expr_adapted)
+        is_not(expr, expr_adapted)
         is_(adapter.columns[expr], expr_adapted)
 
     def test_wrapping_fallthrough(self):
@@ -1112,7 +1113,7 @@ class ColumnAdapterTest(fixtures.TestBase, AssertsCompiledSQL):
         is_(a1_to_a2.columns[t2.c.col1], stmt2.c.table2_col1)
 
         # check that these aren't the same column
-        is_not_(stmt2.c.col1, stmt2.c.table2_col1)
+        is_not(stmt2.c.col1, stmt2.c.table2_col1)
 
         # for mutually exclusive columns, order doesn't matter
         is_(a2_to_a1.columns[t1.c.col1], stmt2.c.table1_col1)
@@ -2031,8 +2032,8 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
             select_copy,
             "SELECT table1.col1, table1.col2, " "table1.col3, yyy FROM table1",
         )
-        is_not_(s.selected_columns, select_copy.selected_columns)
-        is_not_(s._raw_columns, select_copy._raw_columns)
+        is_not(s.selected_columns, select_copy.selected_columns)
+        is_not(s._raw_columns, select_copy._raw_columns)
         self.assert_compile(
             s, "SELECT table1.col1, table1.col2, " "table1.col3 FROM table1"
         )

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -57,7 +57,8 @@ from sqlalchemy.testing import eq_
 from sqlalchemy.testing import expect_warnings
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.types import ARRAY
 from sqlalchemy.types import Boolean
 from sqlalchemy.types import Concatenable
@@ -2129,7 +2130,7 @@ class NegationTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         expr = not_(orig_expr)
         isinstance(expr, Label)
         eq_(expr.name, "foo")
-        is_not_(expr, orig_expr)
+        is_not(expr, orig_expr)
         is_(expr._element.operator, operator.inv)  # e.g. and not false_
 
         self.assert_compile(
@@ -2143,7 +2144,7 @@ class NegationTest(fixtures.TestBase, testing.AssertsCompiledSQL):
             self.table1.c.myid == 1, self.table1.c.myid == 2
         ).self_group()
         expr = not_(orig_expr)
-        is_not_(expr, orig_expr)
+        is_not(expr, orig_expr)
 
         self.assert_compile(
             expr,

--- a/test/sql/test_resultset.py
+++ b/test/sql/test_resultset.py
@@ -45,7 +45,8 @@ from sqlalchemy.testing import is_
 from sqlalchemy.testing import is_true
 from sqlalchemy.testing import le_
 from sqlalchemy.testing import ne_
-from sqlalchemy.testing import not_in_
+from sqlalchemy.testing import not_in
+from sqlalchemy.testing import not_in_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing.mock import Mock
 from sqlalchemy.testing.mock import patch
 from sqlalchemy.testing.schema import Column
@@ -204,17 +205,17 @@ class CursorResultTest(fixtures.TablesTest):
 
         row = connection.execute(content.select(use_labels=True)).first()
         in_(content.c.type, row._mapping)
-        not_in_(bar.c.content_type, row._mapping)
+        not_in(bar.c.content_type, row._mapping)
 
-        not_in_(bar.c.content_type, row._mapping)
+        not_in(bar.c.content_type, row._mapping)
 
         row = connection.execute(
             select([func.now().label("content_type")])
         ).first()
 
-        not_in_(content.c.type, row._mapping)
+        not_in(content.c.type, row._mapping)
 
-        not_in_(bar.c.content_type, row._mapping)
+        not_in(bar.c.content_type, row._mapping)
 
     def test_pickled_rows(self, connection):
         users = self.tables.users
@@ -487,15 +488,15 @@ class CursorResultTest(fixtures.TablesTest):
         ).first()
 
         if testing.against("sqlite < 3.10.0"):
-            not_in_("user_id", r)
-            not_in_("user_name", r)
+            not_in("user_id", r)
+            not_in("user_name", r)
             eq_(r["users.user_id"], 1)
             eq_(r["users.user_name"], "john")
 
             eq_(list(r._fields), ["users.user_id", "users.user_name"])
         else:
-            not_in_("users.user_id", r._mapping)
-            not_in_("users.user_name", r._mapping)
+            not_in("users.user_id", r._mapping)
+            not_in("users.user_name", r._mapping)
             eq_(r._mapping["user_id"], 1)
             eq_(r._mapping["user_name"], "john")
 
@@ -522,8 +523,8 @@ class CursorResultTest(fixtures.TablesTest):
             eq_(r._mapping["users.user_id"], 1)
             eq_(r._mapping["users.user_name"], "john")
         else:
-            not_in_("users.user_id", r._mapping)
-            not_in_("users.user_name", r._mapping)
+            not_in("users.user_id", r._mapping)
+            not_in("users.user_name", r._mapping)
 
         eq_(list(r._fields), ["user_id", "user_name"])
 
@@ -542,7 +543,7 @@ class CursorResultTest(fixtures.TablesTest):
         ).first()
         eq_(r._mapping["users.user_id"], 1)
         eq_(r._mapping["users.user_name"], "john")
-        not_in_("user_name", r._mapping)
+        not_in("user_name", r._mapping)
         eq_(list(r._fields), ["users.user_id", "users.user_name"])
 
     def test_column_accessor_unary(self, connection):
@@ -692,7 +693,7 @@ class CursorResultTest(fixtures.TablesTest):
 
         in_("case_insensitive", row._keymap)
         in_("CaseSensitive", row._keymap)
-        not_in_("casesensitive", row._keymap)
+        not_in("casesensitive", row._keymap)
 
         eq_(row._mapping["case_insensitive"], 1)
         eq_(row._mapping["CaseSensitive"], 2)
@@ -719,7 +720,7 @@ class CursorResultTest(fixtures.TablesTest):
 
             in_("case_insensitive", row._keymap)
             in_("CaseSensitive", row._keymap)
-            not_in_("casesensitive", row._keymap)
+            not_in("casesensitive", row._keymap)
 
             eq_(row._mapping["case_insensitive"], 1)
             eq_(row._mapping["CaseSensitive"], 2)
@@ -1072,11 +1073,11 @@ class CursorResultTest(fixtures.TablesTest):
         eq_(keys, ["user_id", "user_name"])
         ne_(keys, ["user_name", "user_id"])
         in_("user_id", keys)
-        not_in_("foo", keys)
+        not_in("foo", keys)
         in_(users.c.user_id, keys)
-        not_in_(0, keys)
-        not_in_(addresses.c.user_id, keys)
-        not_in_(addresses.c.address, keys)
+        not_in(0, keys)
+        not_in(addresses.c.user_id, keys)
+        not_in(addresses.c.address, keys)
 
         if isinstance(obj, Row):
             eq_(obj._fields, ("user_id", "user_name"))
@@ -1092,7 +1093,7 @@ class CursorResultTest(fixtures.TablesTest):
         eq_(row._fields, ("user_id", "user_name"))
 
         in_("user_id", row.keys())
-        not_in_("foo", row.keys())
+        not_in("foo", row.keys())
         in_(users.c.user_id, row.keys())
 
     def test_row_keys_legacy_dont_warn(self, connection):

--- a/test/sql/test_selectable.py
+++ b/test/sql/test_selectable.py
@@ -45,7 +45,8 @@ from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import in_
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import ne_
 
 
@@ -2601,14 +2602,14 @@ class AnnotationsTest(fixtures.TestBase):
         ):
             eq_(elem, {})
 
-        is_not_(b2.left, bin_.left)
-        is_not_(b3.left, b2.left)
-        is_not_(b2.left, bin_.left)
+        is_not(b2.left, bin_.left)
+        is_not(b3.left, b2.left)
+        is_not(b2.left, bin_.left)
         is_(b4.left, bin_.left)  # since column is immutable
         # deannotate copies the element
-        is_not_(bin_.right, b2.right)
-        is_not_(b2.right, b3.right)
-        is_not_(b3.right, b4.right)
+        is_not(bin_.right, b2.right)
+        is_not(b2.right, b3.right)
+        is_not(b3.right, b4.right)
 
     def test_deannotate_clone(self):
         table1 = table("table1", column("col1"), column("col2"))
@@ -2634,8 +2635,8 @@ class AnnotationsTest(fixtures.TestBase):
         eq_(s3._raw_columns[0]._annotations, {})
         eq_(s4._raw_columns[0]._annotations, {})
 
-        is_not_(s3, s2)
-        is_not_(s4, s3)  # deep deannotate makes a clone unconditionally
+        is_not(s3, s2)
+        is_not(s4, s3)  # deep deannotate makes a clone unconditionally
 
         is_(s3._deannotate(), s3)  # regular deannotate returns same object
 

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -78,7 +78,8 @@ from sqlalchemy.testing import eq_
 from sqlalchemy.testing import expect_warnings
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
-from sqlalchemy.testing import is_not_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import is_not_  # noqa Issue#5429 Legacy Support
 from sqlalchemy.testing import mock
 from sqlalchemy.testing import pickleable
 from sqlalchemy.testing.schema import Column
@@ -2728,12 +2729,12 @@ class ExpressionTest(
         expr = tab.c.avalue["foo"] == "bar"
 
         is_(expr.right.type._type_affinity, String)
-        is_not_(expr.right.type, my_json_normal)
+        is_not(expr.right.type, my_json_normal)
 
         expr = tab.c.bvalue["foo"] == "bar"
 
         is_(expr.right.type._type_affinity, String)
-        is_not_(expr.right.type, my_json_variant)
+        is_not(expr.right.type, my_json_variant)
 
     def test_variant_righthand_coercion_returns_self(self):
         my_datetime_normal = DateTime()


### PR DESCRIPTION
this is safe for 1.3.x

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
