### PR TITLE
Returned "GitHub Actions" support for py27 and py36 environments.

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -15,7 +15,7 @@ jobs:
   # two jobs are defined make-wheel-win-osx and make-wheel-linux.
   # they do the the same steps, but linux wheels need to be build to target manylinux
   make-wheel-win-osx:
-    name: ${{ matrix.python-version }}-${{ matrix.architecture }}-${{ matrix.os }}
+    name: wheel-win-osx-${{ matrix.python-version }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -123,12 +123,13 @@ jobs:
           twine upload --skip-existing dist/*
 
   make-wheel-linux:
-    name: ${{ matrix.python-version }}-${{ matrix.architecture }}-${{ matrix.os }}
+    name: wheel-linux-${{ matrix.python-version }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os:
           - "ubuntu-latest"
+          - "ubuntu-20.04"
         python-version:
           # the versions are <python tag>-<abi tag> as specified in PEP 425.
           - cp27-cp27m
@@ -147,6 +148,26 @@ jobs:
             extra-requires: "mock"
           - python-version: "cp27-cp27mu"
             extra-requires: "mock"
+
+        exclude:
+          # ubuntu-latest does not have: py27, py36
+          - os: "ubuntu-latest"
+            python-version: cp27-cp27m
+          - os: "ubuntu-latest"
+            python-version: cp27-cp27mu
+          - os: "ubuntu-latest"
+            python-version: cp36-cp36m
+          # ubuntu-20.04 does not need to test what ubuntu-latest supports
+          - os: "ubuntu-20.04"
+            python-version: cp37-cp37m
+          - os: "ubuntu-20.04"
+            python-version: cp38-cp38
+          - os: "ubuntu-20.04"
+            python-version: cp39-cp39
+          - os: "ubuntu-20.04"
+            python-version: cp310-cp310
+          - os: "ubuntu-20.04"
+            python-version: cp311-cp311
 
       fail-fast: false
 
@@ -281,12 +302,13 @@ jobs:
           twine upload --skip-existing dist/*manylinux*
 
   make-wheel-linux-arm64:
-    name: ${{ matrix.python-version }}-arm64-${{ matrix.os }}
+    name: wheel-linux-arm64-${{ matrix.python-version }}-arm64-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os:
           - "ubuntu-latest"
+          - "ubuntu-20.04"
         python-version:
           # the versions are <python tag>-<abi tag> as specified in PEP 425.
           - cp36-cp36m
@@ -295,6 +317,21 @@ jobs:
           - cp39-cp39
           - cp310-cp310
           - cp311-cp311
+        exclude:
+          # ubuntu-latest does not have: py27, py36
+          - os: "ubuntu-latest"
+            python-version: cp36-cp36m
+          # ubuntu-20.04 does not need to test what ubuntu-latest supports
+          - os: "ubuntu-20.04"
+            python-version: cp37-cp37m
+          - os: "ubuntu-20.04"
+            python-version: cp38-cp38
+          - os: "ubuntu-20.04"
+            python-version: cp39-cp39
+          - os: "ubuntu-20.04"
+            python-version: cp310-cp310
+          - os: "ubuntu-20.04"
+            python-version: cp311-cp311
 
       fail-fast: false
 

--- a/.github/workflows/run-on-pr.yaml
+++ b/.github/workflows/run-on-pr.yaml
@@ -17,13 +17,14 @@ permissions:
 
 jobs:
   run-test-amd64:
-    name: ${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
+    name: test-amd64-${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # run this job using this matrix, excluding some combinations below.
       matrix:
         os:
           - "ubuntu-latest"
+          - "ubuntu-20.04"
         python-version:
           - "2.7"
           - "3.10"
@@ -32,6 +33,14 @@ jobs:
           - "nocext"
         architecture:
           - x64
+        exclude:
+          # ubuntu-latest does not have: py27, py36
+          - os: "ubuntu-latest"
+            python-version: "2.7"
+          # ubuntu-20.04 does not need to test what ubuntu-latest supports
+          - os: "ubuntu-20.04"
+            python-version: "3.10"
+
       # abort all jobs as soon as one fails
       fail-fast: true
 

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -21,13 +21,14 @@ permissions:
 
 jobs:
   run-test:
-    name: ${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
+    name: test-${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # run this job using this matrix, excluding some combinations below.
       matrix:
         os:
           - "ubuntu-latest"
+          - "ubuntu-20.04"
           - "windows-latest"
           - "macos-latest"
         python-version:
@@ -55,6 +56,8 @@ jobs:
           # add aiosqlite on linux
           - os: "ubuntu-latest"
             pytest-args: "--dbdriver pysqlite --dbdriver aiosqlite"
+          - os: "ubuntu-20.04"
+            pytest-args: "--dbdriver pysqlite --dbdriver aiosqlite"
 
         exclude:
           # c-extensions fail to build on windows for python 2.7
@@ -64,8 +67,26 @@ jobs:
           # linux and osx do not have x86 python
           - os: "ubuntu-latest"
             architecture: x86
+          - os: "ubuntu-20.04"
+            architecture: x86
           - os: "macos-latest"
             architecture: x86
+          # ubuntu-latest does not have: py27, py36
+          - os: "ubuntu-latest"
+            python-version: "2.7"
+          - os: "ubuntu-latest"
+            python-version: "3.6"
+          # ubuntu-20.04 does not need to test what ubuntu-latest supports
+          - os: "ubuntu-20.04"
+            python-version: "3.7"
+          - os: "ubuntu-20.04"
+            python-version: "3.8"
+          - os: "ubuntu-20.04"
+            python-version: "3.9"
+          - os: "ubuntu-20.04"
+            python-version: "3.10"
+          - os: "ubuntu-20.04"
+            python-version: "3.11.0-rc - 3.11"
           # pypy does not have cext
           # - python-version: "pypy-3.9"
           #   build-type: "cext"
@@ -96,10 +117,13 @@ jobs:
         run: tox -e github-${{ matrix.build-type }} -- -q --nomemory --notimingintensive ${{ matrix.pytest-args }}
 
   run-test-arm64:
-    name: ${{ matrix.python-version }}-${{ matrix.build-type }}-arm64-ubuntu-latest
-    runs-on: ubuntu-latest
+    name: arm64-${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os:
+          - "ubuntu-latest"
+          - "ubuntu-20.04"
         python-version:
           - cp36-cp36m
           - cp37-cp37m
@@ -110,6 +134,21 @@ jobs:
         build-type:
           - "cext"
           - "nocext"
+        exclude:
+          # ubuntu-latest does not have: py27, py36
+          - os: "ubuntu-latest"
+            python-version: cp36-cp36m
+          # ubuntu-20.04 does not need to test what ubuntu-latest supports
+          - os: "ubuntu-20.04"
+            python-version: cp37-cp37m
+          - os: "ubuntu-20.04"
+            python-version: cp38-cp38m
+          - os: "ubuntu-20.04"
+            python-version: cp39-cp39m
+          - os: "ubuntu-20.04"
+            python-version: cp310-cp310m
+          - os: "ubuntu-20.04"
+            python-version: cp311-cp311m
 
       fail-fast: false
 
@@ -135,13 +174,14 @@ jobs:
             "
 
   run-mypy:
-    name: mypy-${{ matrix.python-version }}
+    name: mypy-${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # run this job using this matrix, excluding some combinations below.
       matrix:
         os:
           - "ubuntu-latest"
+          - "ubuntu-20.04"
         python-version:
           - "3.6"
           - "3.7"
@@ -149,6 +189,21 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11.0-rc - 3.11"
+        exclude:
+          # ubuntu-latest does not have: py27, py36
+          - os: "ubuntu-latest"
+            python-version: "3.6"
+          # ubuntu-20.04 does not need to test what ubuntu-latest supports
+          - os: "ubuntu-20.04"
+            python-version: "3.7"
+          - os: "ubuntu-20.04"
+            python-version: "3.8"
+          - os: "ubuntu-20.04"
+            python-version: "3.9"
+          - os: "ubuntu-20.04"
+            python-version: "3.10"
+          - os: "ubuntu-20.04"
+            python-version: "3.11.0-rc - 3.11"
       fail-fast: false
 
     # steps to run in each job. Some are github actions, others run shell commands
@@ -172,10 +227,9 @@ jobs:
         run: tox -e mypy ${{ matrix.pytest-args }}
 
   run-pep8:
-    name: pep8-${{ matrix.python-version }}
+    name: pep8-${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      # run this job using this matrix, excluding some combinations below.
       matrix:
         os:
           - "ubuntu-latest"


### PR DESCRIPTION
Returned "GitHub Actions" support for py27 and py36 environments.

GitHub recently upgraded the `ubuntu-latest` operating system label to
point to `ubuntu-22.04` instead of `ubuntu-22.04`.  The `ubuntu-22.04` build
does not support Python 2.7 or 3.6.

In order to return support for CI Testing and release builds, the affected jobs
now utilize `include` and `exclude` commands in run matrixes to enable and
disable jobs under certain environments.

Jobs that requres Py27 and Py36 now run under an explicitly identified
`ubuntu-20.04` operating system. The majority of jobs require Py37 or higher,
which are all currently supported in the new `ubuntu-latest` operating system (
which points to `ubuntu-22.04`).

Although `ubuntu-20.04` should continue to receive support for several more
years, the `ubuntu-22.04` platform is likely to benefit from patch releases on
a faster schedule – so it is preferable to continue running all compatible
tests on `ubuntu-latest` rather than pinning everything to the earlier os
version.

Several jobs were also standardized to use the job "name" as a prefix, a 
convention that most jobs in the workflows already adapted. This practice
greatly simplifies correlating failed tests to specific jobs.

See::

* https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/
* https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/
